### PR TITLE
docs: fix docs wording and typos

### DIFF
--- a/src/content/docs/1.0/getting-started.mdx
+++ b/src/content/docs/1.0/getting-started.mdx
@@ -6,7 +6,7 @@ slug: 1.0/getting-started
 
 import { Tabs, TabItem } from '@astrojs/starlight/components'
 
-Want to get up and running as quickly as possible to see what all the fuss is about?
+Want to get up and running as quickly as possible?
 Use our bootstrap scripts! Follow our Quick Start to get started!
 
 ## Quick Start
@@ -186,7 +186,7 @@ You will then need to install the farmer on the management server. The farmer is
           - FARMERINTERFACE=0.0.0.0
         volumes:
           - ./local/farmer:/etc/grlx
-          # This is where the farmer whill store its recipes
+          # This is where the farmer will store its recipes
           - ./local/data:/srv/grlx
         ports:
           - "5405:5405"

--- a/src/content/docs/1.0/glossary.md
+++ b/src/content/docs/1.0/glossary.md
@@ -14,7 +14,7 @@ The sprout is a managed node running the `grlx-sprout` binary. Sprouts receive c
 
 ## CLI (grlx CLI)
 
-The CLI is a tool used to interact with the farmer and manage sprouts. The CLI is used to accept keys from sprouts and `cook` (run) recipes that are hosted on the farmer. The CLI also contains tools to tail the traffic over the NAT bus, test sprout connections, and run arbitrary commands on sprouts.
+The CLI is a tool used to interact with the farmer and manage sprouts. The CLI is used to accept keys from sprouts and `cook` (run) recipes that are hosted on the farmer. The CLI also contains tools to tail the traffic over the NATS bus, test sprout connections, and run arbitrary commands on sprouts.
 
 ## Authentication
 
@@ -34,7 +34,7 @@ Hooks provide a way to fire off webhooks when recipe deployment (cook) starts, f
 
 ## Template Engine
 
-Templating is achieved with [Go’s builtin templating engine](https://pkg.go.dev/text/template). This provides a Jinja-like templating system that hooks into the Farmer and Sprout properties to customize recipes to meet the dynamic needs of your needs.
+Templating is achieved with [Go’s built-in templating engine](https://pkg.go.dev/text/template). This provides a Jinja-like templating system that hooks into Farmer and Sprout properties to customize recipes to meet your needs.
 
 ## Job Enqueuing and Processing
 

--- a/src/content/docs/getting-started.mdx
+++ b/src/content/docs/getting-started.mdx
@@ -5,7 +5,7 @@ description: Getting Started with grlx
 
 import { Tabs, TabItem } from '@astrojs/starlight/components'
 
-Want to get up and running as quickly as possible to see what all the fuss is about?
+Want to get up and running as quickly as possible?
 Use our bootstrap scripts! Follow our Quick Start to get started!
 
 ## Quick Start
@@ -175,7 +175,7 @@ You will then need to install the farmer on the management server. The farmer is
           - FARMERINTERFACE=0.0.0.0
         volumes:
           - ./local/farmer:/etc/grlx
-          # This is where the farmer whill store its recipes
+          # This is where the farmer will store its recipes
           - ./local/data:/srv/grlx
         ports:
           - "5405:5405"

--- a/src/content/docs/glossary.md
+++ b/src/content/docs/glossary.md
@@ -13,7 +13,7 @@ The sprout is a managed node running the `grlx-sprout` binary. Sprouts receive c
 
 ## CLI (grlx CLI)
 
-The CLI is a tool used to interact with the farmer and manage sprouts. The CLI is used to accept keys from sprouts and `cook` (run) recipes that are hosted on the farmer. The CLI also contains tools to tail the traffic over the NAT bus, test sprout connections, and run arbitrary commands on sprouts.
+The CLI is a tool used to interact with the farmer and manage sprouts. The CLI is used to accept keys from sprouts and `cook` (run) recipes that are hosted on the farmer. The CLI also contains tools to tail the traffic over the NATS bus, test sprout connections, and run arbitrary commands on sprouts.
 
 ## Authentication
 
@@ -37,7 +37,7 @@ Hooks provide a way to fire off webhooks when recipe deployment (cook) starts, f
 
 ## Template Engine
 
-Templating is achieved with [Go’s builtin templating engine](https://pkg.go.dev/text/template). This provides a Jinja-like templating system that hooks into the Farmer and Sprout properties to customize recipes to meet the dynamic needs of your needs.
+Templating is achieved with [Go’s built-in templating engine](https://pkg.go.dev/text/template). This provides a Jinja-like templating system that hooks into Farmer and Sprout properties to customize recipes to meet your needs.
 
 ## Job Enqueuing and Processing
 


### PR DESCRIPTION
## Summary
- fix a few obvious wording/typo issues in getting-started and glossary docs
- update both the current and 1.0 versioned docs so they stay in sync
- keep the change set small and non-conflicting with the open dependency PR

## Testing
- bun run format
- bun run check
- bun run build
- bun run lint