### PR TITLE
docs(copy): polish homepage and recipe wording

### DIFF
--- a/src/content/docs/1.0/index.mdx
+++ b/src/content/docs/1.0/index.mdx
@@ -11,7 +11,7 @@ hero:
       link: /1.0/getting-started/
       icon: right-arrow
       variant: primary
-    - text: Check out our GitHub
+    - text: View the GitHub repo
       link: https://github.com/gogrlx/grlx
       icon: github
 slug: "1.0"
@@ -22,24 +22,25 @@ import { Card, CardGrid } from '@astrojs/starlight/components'
 ## Next steps
 
 <CardGrid stagger>
-  <Card title="Install grlx with our Getting Started" icon="laptop">
-    Check out our [Getting Started](/1.0/getting-started) page to learn how to
-    install grlx
+  <Card title="Install grlx" icon="laptop">
+    Follow the [Getting Started guide](/1.0/getting-started) to install grlx
+    and initialize your first farmer and sprout.
   </Card>
 
-  <Card title="Learn about ingredient components" icon="setting">
-    Check out our [ingredients](/1.0/ingredients/overview) to learn more about how
-    to configure your fleet
+  <Card title="Explore ingredients" icon="setting">
+    Browse the [ingredients docs](/1.0/ingredients/overview) to see how grlx
+    models files, services, users, and more.
   </Card>
 
-  <Card title="Get more info" icon="open-book" class="open-book">
-    Check out the [Glossary](/1.0/glossary) for more info on grlx concepts
+  <Card title="Learn the core concepts" icon="open-book" class="open-book">
+    Read the [Glossary](/1.0/glossary) for quick explanations of grlx terms and
+    architecture.
   </Card>
 
   <div class="discord-bg">
-    <Card title="Join our Discord" icon="discord" class="discord">
-      Join our [Discord](https://discord.gg/RNsZ3KWjXm) for learning more about
-      grlx
+    <Card title="Join the community" icon="discord" class="discord">
+      Join our [Discord](https://discord.gg/RNsZ3KWjXm) to ask questions, share
+      feedback, and learn from other grlx users.
     </Card>
   </div>
 </CardGrid>

--- a/src/content/docs/1.0/index.mdx
+++ b/src/content/docs/1.0/index.mdx
@@ -23,7 +23,7 @@ import { Card, CardGrid } from '@astrojs/starlight/components'
 
 <CardGrid stagger>
   <Card title="Install grlx with our Getting Started" icon="laptop">
-    Check out our [Getting Started](/1.0/getting-started) started page on how to
+    Check out our [Getting Started](/1.0/getting-started) page to learn how to
     install grlx
   </Card>
 

--- a/src/content/docs/1.0/recipes/overview.md
+++ b/src/content/docs/1.0/recipes/overview.md
@@ -4,7 +4,7 @@ description: An overview of grlx recipes
 slug: 1.0/recipes/overview
 ---
 
-Recipes are the core of grlx functionality, providing a structured way for developers to deploy actions to sprouts. Recipes are a collection of ingredients which can be executed against a sprout. Recipes must be placed on the farmer at `/srv/grlx/recipes/prod` (with support for other non-prod environments in the future). Furthermore, recipes can utilize [Go's builtin templating engine](https://pkg.go.dev/text/template) to provide dynamic functionality for deployment. Below is a simple example of the makeup of a recipe.
+Recipes are the core of grlx functionality, providing a structured way for developers to deploy actions to sprouts. Recipes are a collection of ingredients that can be executed against a sprout. Recipes must be placed on the farmer at `/srv/grlx/recipes/prod` (with support for other non-prod environments in the future). Furthermore, recipes can use [Go's built-in templating engine](https://pkg.go.dev/text/template) to provide dynamic functionality for deployment. Below is a simple example of the makeup of a recipe.
 
 ```yaml
 include:

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -11,7 +11,7 @@ hero:
       link: /getting-started/
       icon: right-arrow
       variant: primary
-    - text: Check out our GitHub
+    - text: View the GitHub repo
       link: https://github.com/gogrlx/grlx
       icon: github
 ---
@@ -21,21 +21,22 @@ import { Card, CardGrid } from '@astrojs/starlight/components'
 ## Next steps
 
 <CardGrid stagger>
-  <Card title="Install grlx with our Getting Started" icon="laptop">
-    Check out our [Getting Started](/getting-started) page to learn how to
-    install grlx
+  <Card title="Install grlx" icon="laptop">
+    Follow the [Getting Started guide](/getting-started) to install grlx and
+    initialize your first farmer and sprout.
   </Card>
-  <Card title="Learn about ingredient components" icon="setting">
-    Check out our [ingredients](/ingredients/overview) to learn more about how
-    to configure your fleet
+  <Card title="Explore ingredients" icon="setting">
+    Browse the [ingredients docs](/ingredients/overview) to see how grlx models
+    files, services, users, and more.
   </Card>
-  <Card title="Get more info" icon="open-book" class="open-book">
-    Check out the [Glossary](/glossary) for more info on grlx concepts
+  <Card title="Learn the core concepts" icon="open-book" class="open-book">
+    Read the [Glossary](/glossary) for quick explanations of grlx terms and
+    architecture.
   </Card>
   <div class="discord-bg">
-    <Card title="Join our Discord" icon="discord" class="discord">
-      Join our [Discord](https://discord.gg/RNsZ3KWjXm) for learning more about
-      grlx
+    <Card title="Join the community" icon="discord" class="discord">
+      Join our [Discord](https://discord.gg/RNsZ3KWjXm) to ask questions, share
+      feedback, and learn from other grlx users.
     </Card>
   </div>
 </CardGrid>

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -22,7 +22,7 @@ import { Card, CardGrid } from '@astrojs/starlight/components'
 
 <CardGrid stagger>
   <Card title="Install grlx with our Getting Started" icon="laptop">
-    Check out our [Getting Started](/getting-started) started page on how to
+    Check out our [Getting Started](/getting-started) page to learn how to
     install grlx
   </Card>
   <Card title="Learn about ingredient components" icon="setting">

--- a/src/content/docs/recipes/overview.md
+++ b/src/content/docs/recipes/overview.md
@@ -3,7 +3,7 @@ title: Overview
 description: An overview of grlx recipes
 ---
 
-Recipes are the core of grlx functionality, providing a structured way for developers to deploy actions to sprouts. Recipes are a collection of ingredients which can be executed against a sprout. Recipes must be placed on the farmer at `/srv/grlx/recipes/prod` (with support for other non-prod environments in the future). Furthermore, recipes can utilize [Go's builtin templating engine](https://pkg.go.dev/text/template) to provide dynamic functionality for deployment. Below is a simple example of the makeup of a recipe.
+Recipes are the core of grlx functionality, providing a structured way for developers to deploy actions to sprouts. Recipes are a collection of ingredients that can be executed against a sprout. Recipes must be placed on the farmer at `/srv/grlx/recipes/prod` (with support for other non-prod environments in the future). Furthermore, recipes can use [Go's built-in templating engine](https://pkg.go.dev/text/template) to provide dynamic functionality for deployment. Below is a simple example of the makeup of a recipe.
 
 ```yaml
 include:


### PR DESCRIPTION
## Summary
- tighten the Getting Started card copy on both the latest and 1.0 landing pages
- clean up recipe overview wording in both versions
- keep this separate from the existing typo and dependency PRs

## Testing
- bun run format
- bun run check
- bun run build