### PR TITLE
fix(docs): add custom not found page

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -116,6 +116,7 @@ export default defineConfig({
       ],
       title: 'grlx Docs',
       lastUpdated: true,
+      disable404Route: true,
       description:
         'Documentation for grlx. Fleet configuration management that is low overhead, dependency free, and easy to install.',
       components: {

--- a/src/content/docs/404.md
+++ b/src/content/docs/404.md
@@ -1,0 +1,17 @@
+---
+title: '404'
+description: Page not found
+template: splash
+editUrl: false
+hero:
+  title: '404'
+  tagline: Page not found. Check the URL or use search to find the grlx docs you need.
+  actions:
+    - text: Start from the docs home
+      link: /
+      icon: right-arrow
+      variant: primary
+    - text: Browse getting started
+      link: /getting-started/
+      icon: open-book
+---


### PR DESCRIPTION
## Summary
- add a branded Starlight 404 content page with links back into the docs
- disable Starlight's injected default 404 route so the custom route builds cleanly

## Tests
- bun run check
- bun run lint
- bun run format
- bun run build